### PR TITLE
:arrow_up: symfony 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog for NetBrothers SyncAcc
 ===================================
 
+Version 1.0.0 - 06.12.2023
+----------------------------------
+- Fixing Deprecated Since symfony/console 6.1: Relying on the static property "$defaultName"
+  for setting a command name is deprecated.
+- updated symfony requirements to >=6 <7
+- updated php requirements to >=8.1
+- Upgrading Version-Number to 2.0.0
+
+
 Version 0.1.0 - 22.08.2023
 ----------------------------------
 - Replace annotations with attributes for using in Symfony ^6.3

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=8.1",
     "ext-json": "*",
-    "symfony/console": "^6.3"
+    "symfony/console": ">=6 <7"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
symfony requirements updated in composer.json to >=6 <7